### PR TITLE
Close #75.  Fixed extra spaces in the text field 

### DIFF
--- a/resources/views/searches/create.blade.php
+++ b/resources/views/searches/create.blade.php
@@ -231,27 +231,21 @@
                 <!-- Incident zone - OPEN  -->
                 <div class="form-group col-md-6">
                     <label for="zone_incident"> {{ __('forms.incident_zone') }} </label>
-                    <textarea type="text" class="form-control" name="zone_incident" rows="2">
-                        {{ old('zone_incident') }}
-                    </textarea>
+                    <textarea type="text" class="form-control" name="zone_incident" rows="2">{{ old('zone_incident') }}</textarea>
                 </div>
                 <!-- Incident zone - CLOSE  -->
 
                 <!-- Incident route - OPEN  -->
                 <div class="form-group col-md-6">
                     <label for="potential_route"> {{ __('forms.possible_route') }} </label>
-                    <textarea type="text" class="form-control" name="potential_route" rows="2">
-                        {{ old('potential_route') }}
-                    </textarea>
+                    <textarea type="text" class="form-control" name="potential_route" rows="2">{{ old('potential_route') }}</textarea>
                 </div>
                 <!-- Incident route - CLOSE  -->
 
                 <!-- Incident description - OPEN  -->
                 <div class="form-group col-md-12">
                     <label for="description_incident"> {{ __('forms.description') }} </label>
-                    <textarea type="text" class="form-control" name="description_incident" rows="2">
-                        {{ old('description_incident') }}
-                    </textarea>
+                    <textarea type="text" class="form-control" name="description_incident" rows="2">{{ old('description_incident') }}</textarea>
                 </div>
                 <!-- Incident description - CLOSE  -->
 
@@ -335,9 +329,7 @@
                 <!-- State input - OPEN  -->
                 <div class="form-group col-md-12">
                     <label for="physical_condition_lost_people"> {{ __('forms.description') }} </label>
-                    <textarea type="number" class="form-control" name="physical_condition_lost_people" rows="2">
-                        {{ old('physical_condition_lost_people') }}
-                    </textarea>
+                    <textarea type="number" class="form-control" name="physical_condition_lost_people" rows="2">{{ old('physical_condition_lost_people') }}</textarea>
                 </div>
                 <!-- State input - CLOSE  -->
 

--- a/resources/views/searches/finalization/edit.blade.php
+++ b/resources/views/searches/finalization/edit.blade.php
@@ -68,7 +68,7 @@
 
             <textarea rows="2" name="first_command" class="form-control
             {{ $errors->has('first_command') ? ' is-invalid' : '' }}"
-            > {{ $search->first_command }} </textarea>
+            >{{ $search->first_command }}</textarea>
 
             <!-- Show errors input - OPEN -->
             @if( $errors->has('first_command') )
@@ -88,7 +88,7 @@
 
             <textarea rows="2" name="intermediate_commands" class="form-control
             {{ $errors->has('intermediate_commands') ? ' is-invalid' : '' }}"
-            > {{ $search->intermediate_commands }} </textarea>
+            >{{ $search->intermediate_commands }}</textarea>
 
             <!-- Show errors input - OPEN -->
             @if( $errors->has('intermediate_commands') )
@@ -108,7 +108,7 @@
 
             <textarea rows="2" name="last_command" class="form-control
             {{ $errors->has('last_command') ? ' is-invalid' : '' }}"
-            > {{ $search->last_command }} </textarea>
+            >{{ $search->last_command }}</textarea>
 
             <!-- Show errors input - OPEN -->
             @if( $errors->has('last_command') )
@@ -373,9 +373,8 @@
             {{ Form::label('physical_condition_people_when_find', __('forms.lost_people_state')) }}
 
             <textarea rows="2" name="physical_condition_people_when_find" class="form-control
-            {{ $errors->has('physical_condition_people_when_find') ? ' is-invalid' : '' }}">
-                {{ $search->physical_condition_people_when_find }}
-            </textarea>
+            {{ $errors->has('physical_condition_people_when_find') ? ' is-invalid' : '' }}"
+            >{{ $search->physical_condition_people_when_find }}</textarea>
 
             <!-- Show errors input - OPEN -->
             @if( $errors->has('physical_condition_people_when_find') )
@@ -394,9 +393,8 @@
             {{ Form::label('reason_finalization', __('forms.motive_closing')) }}
 
             <textarea rows="2" name="reason_finalization" class="form-control
-            {{ $errors->has('reason_finalization') ? ' is-invalid' : '' }}">
-                {{ $search->reason_finalization }}
-            </textarea>
+            {{ $errors->has('reason_finalization') ? ' is-invalid' : '' }}"
+            >{{ $search->reason_finalization }}</textarea>
 
             <!-- Show errors input - OPEN -->
             @if( $errors->has('reason_finalization') )


### PR DESCRIPTION
There were extra spaces in the forms due to the indentation of the text field. This has been removed.
**Before:**
![image](https://user-images.githubusercontent.com/7031028/74035904-29c85a00-49f6-11ea-81ab-782ed70daaf7.png)

**After:**
![image](https://user-images.githubusercontent.com/7031028/74080708-eb787c80-4a81-11ea-87bf-cb57a1535406.png)
