### PR TITLE
Fix documentation 404/500 error due to ParsedownExtra PHP 8 incompatibility

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,9 +2,9 @@
 
 namespace App\Providers;
 
-use Illuminate\Support\ServiceProvider;
-use BinaryTorch\LaRecipe\Contracts\MarkdownParser;
 use App\Services\CustomMarkdownParser;
+use BinaryTorch\LaRecipe\Contracts\MarkdownParser;
+use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
 {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,8 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use BinaryTorch\LaRecipe\Contracts\MarkdownParser;
+use App\Services\CustomMarkdownParser;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -13,7 +15,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        //
+        $this->app->bind(MarkdownParser::class, CustomMarkdownParser::class);
     }
 
     /**

--- a/app/Services/CustomMarkdownParser.php
+++ b/app/Services/CustomMarkdownParser.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Services;
+
+use BinaryTorch\LaRecipe\Contracts\MarkdownParser;
+
+class CustomMarkdownParser implements MarkdownParser
+{
+    /**
+     * Parse the given source to Markdown, using your Markdown parser of choice.
+     *
+     * @param string $source Markdown source contents
+     * @return null|string|string[] HTML output
+     */
+    public function parse($source)
+    {
+        return (new CustomParsedownExtra)->text($source);
+    }
+}

--- a/app/Services/CustomMarkdownParser.php
+++ b/app/Services/CustomMarkdownParser.php
@@ -10,10 +10,11 @@ class CustomMarkdownParser implements MarkdownParser
      * Parse the given source to Markdown, using your Markdown parser of choice.
      *
      * @param string $source Markdown source contents
+     *
      * @return null|string|string[] HTML output
      */
     public function parse($source)
     {
-        return (new CustomParsedownExtra)->text($source);
+        return (new CustomParsedownExtra())->text($source);
     }
 }

--- a/app/Services/CustomParsedownExtra.php
+++ b/app/Services/CustomParsedownExtra.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Services;
+
+use ParsedownExtra;
+use ReflectionMethod;
+
+class CustomParsedownExtra extends ParsedownExtra
+{
+    protected function blockHeader($Line)
+    {
+        // Use reflection to call Parsedown::blockHeader
+        $method = new ReflectionMethod(\Parsedown::class, 'blockHeader');
+        $method->setAccessible(true);
+        $Block = $method->invoke($this, $Line);
+
+        if (! isset($Block)) {
+            return null;
+        }
+
+        // Fix for undefined array key "text" in ParsedownExtra
+        if (isset($Block['element']['text']) && preg_match('/[ #]*{('.$this->regexAttribute.'+)}[ ]*$/', $Block['element']['text'], $matches, PREG_OFFSET_CAPTURE))
+        {
+            $attributeString = $matches[1][0];
+
+            $Block['element']['attributes'] = $this->parseAttributeData($attributeString);
+
+            $Block['element']['text'] = substr($Block['element']['text'], 0, $matches[0][1]);
+        }
+
+        return $Block;
+    }
+}

--- a/app/Services/CustomParsedownExtra.php
+++ b/app/Services/CustomParsedownExtra.php
@@ -14,13 +14,12 @@ class CustomParsedownExtra extends ParsedownExtra
         $method->setAccessible(true);
         $Block = $method->invoke($this, $Line);
 
-        if (! isset($Block)) {
+        if (!isset($Block)) {
             return null;
         }
 
         // Fix for undefined array key "text" in ParsedownExtra
-        if (isset($Block['element']['text']) && preg_match('/[ #]*{('.$this->regexAttribute.'+)}[ ]*$/', $Block['element']['text'], $matches, PREG_OFFSET_CAPTURE))
-        {
+        if (isset($Block['element']['text']) && preg_match('/[ #]*{('.$this->regexAttribute.'+)}[ ]*$/', $Block['element']['text'], $matches, PREG_OFFSET_CAPTURE)) {
             $attributeString = $matches[1][0];
 
             $Block['element']['attributes'] = $this->parseAttributeData($attributeString);


### PR DESCRIPTION
Fixed the issue where documentation pages (`/docs/{lang_code_2}`) were returning errors (reported as 404, but actually 500 Internal Server Error).
The root cause was an incompatibility between `erusev/parsedown-extra` 0.8.1 and PHP 8.x, specifically accessing an undefined array key "text" in the `blockHeader` method.

Changes:
- Created `app/Services/CustomParsedownExtra.php` which extends `ParsedownExtra` and fixes the `blockHeader` method using Reflection to call the grandparent method safely.
- Created `app/Services/CustomMarkdownParser.php` which implements `BinaryTorch\LaRecipe\Contracts\MarkdownParser` and uses `CustomParsedownExtra`.
- Updated `app/Providers/AppServiceProvider.php` to bind the `MarkdownParser` interface to `CustomMarkdownParser`.

Verified that `/docs/EN` and `/docs/ES` now load correctly.


---
*PR created automatically by Jules for task [8492249862141062885](https://jules.google.com/task/8492249862141062885) started by @eduayme*